### PR TITLE
Reset buffer list

### DIFF
--- a/tabspaces.el
+++ b/tabspaces.el
@@ -98,7 +98,7 @@ ARG is directly passed to `tab-bar-new-tab'. Only buffers in
 
 (defun tabspaces-reset-buffer-list ()
   "Resets the current tab's `buffer-list'.
-Only the current buffer and buffers in
+Only the current window buffers and buffers in
 `tabspaces-include-buffers' are kept in the `buffer-list' and
 `buried-buffer-list'."
   (interactive)
@@ -107,11 +107,12 @@ Only the current buffer and buffers in
   ;; A hidden tab keeps these as `wc-bl' and `wc-bbl'.
   (set-frame-parameter nil
                        'buffer-list
-                       (seq-filter (lambda (buffer)
-                                     (or (eq buffer (current-buffer))
-                                         (member (buffer-name buffer)
-                                                 tabspaces-include-buffers)))
-                                   (frame-parameter nil 'buffer-list)))
+                       (let ((window-buffers (mapcar #'window-buffer (window-list))))
+                         (seq-filter (lambda (buffer)
+                                       (or (member buffer window-buffers)
+                                           (member (buffer-name buffer)
+                                                   tabspaces-include-buffers)))
+                                     (frame-parameter nil 'buffer-list))))
   (set-frame-parameter nil
                        'buried-buffer-list
                        (seq-filter (lambda (buffer)

--- a/tabspaces.el
+++ b/tabspaces.el
@@ -100,8 +100,9 @@ ARG is directly passed to `tab-bar-new-tab'. Only buffers in
   (set-frame-parameter nil
                        'buffer-list
                        (seq-filter (lambda (buffer)
-                                     (member (buffer-name buffer)
-                                             tabspaces-include-buffers))
+                                     (or (eq buffer (current-buffer))
+                                         (member (buffer-name buffer)
+                                                 tabspaces-include-buffers)))
                                    (frame-parameter nil 'buffer-list)))
   (set-frame-parameter nil
                        'buried-buffer-list

--- a/tabspaces.el
+++ b/tabspaces.el
@@ -94,6 +94,14 @@ ARG is directly passed to `tab-bar-new-tab'. Only buffers in
 `buried-buffer-list'."
   (interactive)
   (tab-bar-new-tab arg)
+  (tabspaces-reset-buffer-list))
+
+(defun tabspaces-reset-buffer-list ()
+  "Resets the current tab's `buffer-list'.
+Only the current buffer and buffers in
+`tabspaces-include-buffers' are kept in the `buffer-list' and
+`buried-buffer-list'."
+  (interactive)
   ;; https://www.gnu.org/software/emacs/manual/html_node/elisp/Current-Buffer.html
   ;; The current-tab uses `buffer-list' and `buried-buffer-list'.
   ;; A hidden tab keeps these as `wc-bl' and `wc-bbl'.


### PR DESCRIPTION
This addresses #12 and https://github.com/mclear-tools/tabspaces/issues/9#issuecomment-1107994800. Also further improves the reset to set the `buffer-list` to all visible (in all windows) buffers.