### PR TITLE
Use `project-prompt-project-dir` for better integration

### DIFF
--- a/tabspaces.el
+++ b/tabspaces.el
@@ -378,7 +378,7 @@ workspace. If PROJECT does not exist, create it, along with a
    ;; Select project from completing-read
    (if (eq project--list 'unset)
        (call-interactively #'project-switch-project)
-     (list (completing-read "Project Name: " project--list))))
+     (list (project-prompt-project-dir))))
   ;; Set vars
   (let* ((project-switch-commands #'project-find-file)
          (pname (file-name-nondirectory (directory-file-name project)))


### PR DESCRIPTION
This uses the `project-prompt-project-dir` to get project list. This will make use of any `project.el` packages like `project-nerd-icons`.

## Before

![image](https://github.com/mclear-tools/tabspaces/assets/3716399/fd24f631-f463-4336-8560-35abe24b29fb)

## After

![Screenshot_20230612_154910](https://github.com/mclear-tools/tabspaces/assets/3716399/5565c752-3288-4e3a-82de-c8578e1da7e3)
