### PR TITLE
Fixup and extra prompt information

### DIFF
--- a/tabspaces.el
+++ b/tabspaces.el
@@ -260,7 +260,9 @@ default tabspace."
     (let ((blst (mapcar (lambda (b) (buffer-name b))
                         (tabspaces--buffer-list))))
       ;; select buffer
-      (read-buffer "Remove buffer from tabspace: " nil t
+      (read-buffer (format "Remove buffer from `%s' tabspace: "
+                           (tabspaces--current-tab-name))
+                   nil t
                    (lambda (b) (member (car b) blst))))))
   ;; delete window of buffer
   (cond ((eq buffer (window-buffer (selected-window)))
@@ -273,7 +275,8 @@ default tabspace."
              (bury-buffer)
            (delete-window)))
         (t
-         (message "buffer removed from tabspace")))
+         (message (format "Buffer `%s' removed from `%s' tabspace."
+                          buffer (tabspaces--current-tab-name)))))
   ;; delete buffer from tabspace buffer list
   (delete (get-buffer buffer) (frame-parameter nil 'buffer-list))
   ;; add buffer to default tabspace


### PR DESCRIPTION
Add additional prompts when remove buffer from tabspace

Sometimes I find that when removing a buffer from a tabspace, I still need to confirm whether I am in the correct tabspace.

Adding this works good for me, I guess we can merge it? ;)

---

Second update:

As the commit show, fix the command `tabspaces-remove-current-buffer` since it totally can't work right now, I rewrite it so `tabspaces-remove-select-buffer` can use it too.

And I make `tabspaces--add-to-default-tabspace` do its work without
checking `tabspaces-remove-to-default` (From the function's name,
`tabspaces--add-to-default-tabspace` should only care about add the
removed buffer to `tabspaces-default-tab`, it shouldn't check the
condition inside the function).