### PR TITLE
Fixing bug with open tab not being reused by `tabspaces-open-or-create-project-and-workspace`, creating a duplicate tab

### DIFF
--- a/tabspaces.el
+++ b/tabspaces.el
@@ -470,7 +470,8 @@ If FRAME is nil, use the current frame."
                       (expand-file-name project)  ; Resolve relative paths
                     project))
          (existing-tab-names (tabspaces--list-tabspaces))
-         (tab-name (tabspaces-generate-descriptive-tab-name project existing-tab-names))
+         (tab-name (or (cdr (assoc project tabspaces-project-tab-map)) ; look up if project already associated with tab name
+                       (tabspaces-generate-descriptive-tab-name project existing-tab-names))) ; before generating new name
          (session (concat project "." (file-name-nondirectory (directory-file-name project)) "-tabspaces-session.el"))
          (project-directory (file-name-directory project))
          (directory-with-potential-project-content (project--find-in-directory project-directory)))


### PR DESCRIPTION
Upon invoking `tabspaces-open-or-create-project-and-workspace` on a project that is already open, `tabspaces-generate-descriptive-tab-name` would yield a unique name that would cause the first condition (project and tab exist) to fail.

Instead, this fix leverages the mapping from project directory name to tab name stored in `tabspaces-project-tab-map` to pick the existing tab name instead of generating a unique name when the project is already open.