### PR TITLE
Avoid copying over the currently visible buffer to another tab

### DIFF
--- a/tabspaces.el
+++ b/tabspaces.el
@@ -153,6 +153,8 @@ Only the current window buffers and buffers in
 
 (defun tabspaces--tab-post-open-function (_tab)
   "Reset buffer list on new tab creation."
+  ;; avoid copying over the currently visible buffer by switching to *scratch*
+  (switch-to-buffer "*scratch*")
   (tabspaces-reset-buffer-list))
 
 ;;;; Filter Workspace Buffers


### PR DESCRIPTION
When running `tabspaces-open-or-create-project-and-workspace`, the currently active buffer is copied to the new tab and is not filtered out by `tabspaces-reset-buffer-list`.

This fix switches the current buffer to `*scratch*` before running `tabspaces-reset-buffer-list`.

This assumes that `*scratch*` is part of `tabspaces-include-buffers`. If not, one could add a new `defcustom` with the name of the buffer the display should be switched to instead of `*scratch*`. 