### PR TITLE
Persist dired, eshell, and shell buffers across session restore

### DIFF
--- a/README.org
+++ b/README.org
@@ -181,8 +181,9 @@ Tabspaces provides basic functionality to save and restore both global (all
 tabspaces) and project-specific tabspace sessions. These sessions store:
 
 - Open file-visiting buffers in each tab
-- Dired, eshell, and shell buffers (via the built-in handlers; see [[#non-file-buffer-restoration][Non-file
-  Buffer Restoration]] below for the hook to add others such as vterm or eat)
+- Dired, eshell, and shell buffers (via the built-in handlers). See
+  [[#non-file-buffer-restoration][Non-file Buffer Restoration]] below for the hook to add others such
+  as vterm or eat.
 - Window configurations (splits, sizes, buffer positions)
 
 **** Configuration
@@ -312,9 +313,9 @@ small registration API; users wire up the kinds they care about in their own
 config. The package itself does not depend on any third-party terminal or
 REPL package.
 
-The save-side handler captures =default-directory= and the buffer name; the
+The save-side handler captures =default-directory= and the buffer name. The
 restore-side handler creates a fresh buffer at the saved directory. Running
-processes are *not* revived -- a restored shell starts a new process; a
+processes are *not* revived. A restored shell starts a new process, and a
 restored eshell starts a new eshell. Histories and output are not preserved.
 
 ****** Registration API
@@ -331,11 +332,11 @@ restored eshell starts a new eshell. Histories and output are not preserved.
   reused, or =nil= to skip the record.
 
 Re-registering a =KIND= replaces the previous entry. The most recently
-registered handler runs first on save; the three built-ins (=dired=,
+registered handler runs first on save. The three built-ins (=dired=,
 =eshell=, =shell=) are registered at package load time and act as
 fallbacks. Restore-fn bodies must create buffers but must *not* call
 window-configuration-changing functions like =pop-to-buffer-other-window=
-or =delete-other-windows= -- the outer restore loop wraps each record's
+or =delete-other-windows=. The outer restore loop wraps each record's
 handler in =save-window-excursion= and then calls =window-state-put= to
 set the final layout.
 
@@ -361,7 +362,7 @@ set the final layout.
    (require 'vterm)
    (let ((name (plist-get rec :name))
          (dir  (plist-get rec :dir)))
-     (or (tabspaces--reuse-existing-buffer name)
+     (or (tabspaces-reuse-existing-buffer name)
          (condition-case err
              (let ((default-directory dir))
                (vterm name))
@@ -377,11 +378,11 @@ message), so handlers do not need their own remote-path checks.
 
 Register at top level, *not* inside =(with-eval-after-load 'THIRD-PARTY ...)=.
 If =tabspaces-session-auto-restore= is =t=, =tabspaces-mode 1= triggers a
-restore immediately on startup; if your vterm handler is wrapped in
+restore immediately on startup. If your vterm handler is wrapped in
 =(with-eval-after-load 'vterm ...)= the registration has not yet fired
 when the restore runs, and any =:kind vterm= records are reported as
 unknown kinds (single summary message) and skipped. Calling =M-x vterm=
-later loads vterm and runs the registration -- but the records are
+later loads vterm and runs the registration, but the records are
 already gone from the session.
 
 The canonical pattern shown above puts =(require 'vterm)= inside the
@@ -404,7 +405,7 @@ pre-compiled, the first restore pays the one-time package-load cost.
   know the restored buffer starts empty.
 - *Single-frame restore*: =tabspaces-restore-session= drives the current
   frame's tabs. Calling it on a second frame performs a second full
-  restore; the dedup check sees the first frame's buffers as foreign and
+  restore. The dedup check sees the first frame's buffers as foreign and
   creates fresh ones.
 - *One-way backward compat*: session files written by this version include
   plist records that older versions cannot read. Downgrading requires
@@ -425,7 +426,7 @@ pre-compiled, the first restore pays the one-time package-load cost.
  (lambda (rec)
    (let ((name (plist-get rec :name))
          (dir  (plist-get rec :dir)))
-     (or (tabspaces--reuse-existing-buffer name)
+     (or (tabspaces-reuse-existing-buffer name)
          (condition-case err
              (let* ((default-directory dir)
                     (program (or explicit-shell-file-name
@@ -450,7 +451,7 @@ pre-compiled, the first restore pays the one-time package-load cost.
  (lambda (rec)
    (let ((name (plist-get rec :name))
          (dir  (plist-get rec :dir)))
-     (or (tabspaces--reuse-existing-buffer name)
+     (or (tabspaces-reuse-existing-buffer name)
          (condition-case err
              (let ((default-directory dir))
                (ielm name))

--- a/README.org
+++ b/README.org
@@ -181,6 +181,8 @@ Tabspaces provides basic functionality to save and restore both global (all
 tabspaces) and project-specific tabspace sessions. These sessions store:
 
 - Open file-visiting buffers in each tab
+- Dired, eshell, and shell buffers (via the built-in handlers; see [[#non-file-buffer-restoration][Non-file
+  Buffer Restoration]] below for the hook to add others such as vterm or eat)
 - Window configurations (splits, sizes, buffer positions)
 
 **** Configuration
@@ -297,6 +299,165 @@ For more granular control over session management, additional functions are avai
 
 These functions are particularly useful when using per-project session storage mode,
 allowing you to selectively save different types of workspaces.
+
+***** Non-file Buffer Restoration
+:PROPERTIES:
+:CUSTOM_ID: non-file-buffer-restoration
+:END:
+
+In addition to file-visiting buffers, tabspaces ships handlers that save and
+restore =dired=, =eshell=, and =shell= buffers as part of a session. For
+other buffer kinds (=term=, =vterm=, =eat=, =ielm=, etc.) tabspaces exposes a
+small registration API; users wire up the kinds they care about in their own
+config. The package itself does not depend on any third-party terminal or
+REPL package.
+
+The save-side handler captures =default-directory= and the buffer name; the
+restore-side handler creates a fresh buffer at the saved directory. Running
+processes are *not* revived -- a restored shell starts a new process; a
+restored eshell starts a new eshell. Histories and output are not preserved.
+
+****** Registration API
+
+#+begin_src elisp
+(tabspaces-register-buffer-kind KIND SAVE-FN RESTORE-FN)
+#+end_src
+
+- =KIND= is a symbol used as the =:kind= value in serialized records.
+- =SAVE-FN= takes a buffer and returns either a plist of the form
+  =(:kind KIND :dir DIR :name NAME ...)= or =nil= to skip the buffer. Add
+  any extra keys your restore-fn needs.
+- =RESTORE-FN= takes such a plist and returns the buffer it created or
+  reused, or =nil= to skip the record.
+
+Re-registering a =KIND= replaces the previous entry. The most recently
+registered handler runs first on save; the three built-ins (=dired=,
+=eshell=, =shell=) are registered at package load time and act as
+fallbacks. Restore-fn bodies must create buffers but must *not* call
+window-configuration-changing functions like =pop-to-buffer-other-window=
+or =delete-other-windows= -- the outer restore loop wraps each record's
+handler in =save-window-excursion= and then calls =window-state-put= to
+set the final layout.
+
+****** Example: vterm
+
+#+begin_src elisp
+;; In init.el, after (require 'tabspaces).
+(tabspaces-register-buffer-kind
+ 'vterm
+ ;; SAVE-FN: only fires for vterm-mode buffers. Safe to define
+ ;; before vterm itself is loaded -- derived-mode-p returns nil
+ ;; for unloaded modes.
+ (lambda (b)
+   (with-current-buffer b
+     (when (derived-mode-p 'vterm-mode)
+       (list :kind 'vterm
+             :dir default-directory
+             :name (buffer-name)))))
+ ;; RESTORE-FN: load vterm lazily, then create the buffer at the saved
+ ;; directory. Wrap the body in condition-case so a single bad record
+ ;; doesn't poison the rest of the restore.
+ (lambda (rec)
+   (require 'vterm)
+   (let ((name (plist-get rec :name))
+         (dir  (plist-get rec :dir)))
+     (or (tabspaces--reuse-existing-buffer name)
+         (condition-case err
+             (let ((default-directory dir))
+               (vterm name))
+           (error
+            (message "tabspaces: vterm restore skipped (%s): %S" dir err)
+            nil))))))
+#+end_src
+
+TRAMP paths are handled at the dispatch layer (skipped with a summary
+message), so handlers do not need their own remote-path checks.
+
+****** Registering after =(require 'tabspaces)=
+
+Register at top level, *not* inside =(with-eval-after-load 'THIRD-PARTY ...)=.
+If =tabspaces-session-auto-restore= is =t=, =tabspaces-mode 1= triggers a
+restore immediately on startup; if your vterm handler is wrapped in
+=(with-eval-after-load 'vterm ...)= the registration has not yet fired
+when the restore runs, and any =:kind vterm= records are reported as
+unknown kinds (single summary message) and skipped. Calling =M-x vterm=
+later loads vterm and runs the registration -- but the records are
+already gone from the session.
+
+The canonical pattern shown above puts =(require 'vterm)= inside the
+restore-fn body, so the third-party package loads only when a record of
+that kind is actually being restored. For users whose package is not
+pre-compiled, the first restore pays the one-time package-load cost.
+
+****** Caveats
+
+- *Cross-tab name collisions*: per-tab dedup wins over name preservation.
+  If two tabs each saved a buffer named =*eshell*=, restoring the second
+  tab's eshell creates a fresh buffer (typically with a =<N>= suffix) so
+  workspace isolation is maintained.
+- *TRAMP*: remote paths are skipped on restore with a summary message
+  ("tabspaces: N remote buffer(s) skipped (TRAMP)") rather than connecting
+  synchronously per buffer. Re-open remote buffers manually after restore.
+- *Shell semantics*: restored shell-mode buffers are fresh processes at
+  the saved =default-directory= -- no command history, no running state.
+  Users with named shells like =*shell-prod*= who depend on history should
+  know the restored buffer starts empty.
+- *Single-frame restore*: =tabspaces-restore-session= drives the current
+  frame's tabs. Calling it on a second frame performs a second full
+  restore; the dedup check sees the first frame's buffers as foreign and
+  creates fresh ones.
+- *One-way backward compat*: session files written by this version include
+  plist records that older versions cannot read. Downgrading requires
+  deleting any saved session files first.
+
+****** More example handlers
+
+#+begin_src elisp
+;; term-mode (and ansi-term) -- spawns a PTY at the saved directory.
+(tabspaces-register-buffer-kind
+ 'term
+ (lambda (b)
+   (with-current-buffer b
+     (when (derived-mode-p 'term-mode)
+       (list :kind 'term
+             :dir default-directory
+             :name (buffer-name)))))
+ (lambda (rec)
+   (let ((name (plist-get rec :name))
+         (dir  (plist-get rec :dir)))
+     (or (tabspaces--reuse-existing-buffer name)
+         (condition-case err
+             (let* ((default-directory dir)
+                    (program (or explicit-shell-file-name
+                                 (getenv "SHELL")
+                                 shell-file-name)))
+               ;; ansi-term wraps make-term with a user-provided buffer
+               ;; name, sidestepping (term)'s hardcoded *terminal* name.
+               (ansi-term program (substring name 1 -1)))
+           (error
+            (message "tabspaces: term restore skipped (%s): %S" dir err)
+            nil))))))
+
+;; ielm -- Emacs Lisp REPL.
+(tabspaces-register-buffer-kind
+ 'ielm
+ (lambda (b)
+   (with-current-buffer b
+     (when (derived-mode-p 'inferior-emacs-lisp-mode)
+       (list :kind 'ielm
+             :dir default-directory
+             :name (buffer-name)))))
+ (lambda (rec)
+   (let ((name (plist-get rec :name))
+         (dir  (plist-get rec :dir)))
+     (or (tabspaces--reuse-existing-buffer name)
+         (condition-case err
+             (let ((default-directory dir))
+               (ielm name))
+           (error
+            (message "tabspaces: ielm restore skipped (%s): %S" dir err)
+            nil))))))
+#+end_src
 
 *** Additional Customization
 

--- a/README.org
+++ b/README.org
@@ -309,9 +309,9 @@ allowing you to selectively save different types of workspaces.
 In addition to file-visiting buffers, tabspaces ships handlers that save and
 restore =dired=, =eshell=, and =shell= buffers as part of a session. For
 other buffer kinds (=term=, =vterm=, =eat=, =ielm=, etc.) tabspaces exposes a
-small registration API; users wire up the kinds they care about in their own
-config. The package itself does not depend on any third-party terminal or
-REPL package.
+small registration API so users can wire up the kinds they care about in
+their own config. The package itself does not depend on any third-party
+terminal or REPL package.
 
 The save-side handler captures =default-directory= and the buffer name. The
 restore-side handler creates a fresh buffer at the saved directory. Running
@@ -347,8 +347,8 @@ set the final layout.
 (tabspaces-register-buffer-kind
  'vterm
  ;; SAVE-FN: only fires for vterm-mode buffers. Safe to define
- ;; before vterm itself is loaded -- derived-mode-p returns nil
- ;; for unloaded modes.
+ ;; before vterm itself is loaded, because derived-mode-p returns
+ ;; nil for unloaded modes.
  (lambda (b)
    (with-current-buffer b
      (when (derived-mode-p 'vterm-mode)
@@ -400,9 +400,9 @@ pre-compiled, the first restore pays the one-time package-load cost.
   ("tabspaces: N remote buffer(s) skipped (TRAMP)") rather than connecting
   synchronously per buffer. Re-open remote buffers manually after restore.
 - *Shell semantics*: restored shell-mode buffers are fresh processes at
-  the saved =default-directory= -- no command history, no running state.
-  Users with named shells like =*shell-prod*= who depend on history should
-  know the restored buffer starts empty.
+  the saved =default-directory=. No command history is preserved, and no
+  running state is revived. Users with named shells like =*shell-prod*=
+  who depend on history should know the restored buffer starts empty.
 - *Single-frame restore*: =tabspaces-restore-session= drives the current
   frame's tabs. Calling it on a second frame performs a second full
   restore. The dedup check sees the first frame's buffers as foreign and

--- a/README.org
+++ b/README.org
@@ -385,6 +385,13 @@ unknown kinds (single summary message) and skipped. Calling =M-x vterm=
 later loads vterm and runs the registration, but the records are
 already gone from the session.
 
+For the same reason, all handler registrations must run *before* the
+call to =(tabspaces-mode 1)= when auto-restore is enabled. Users of
+=use-package= with =:defer t= blocks should be especially careful here:
+put =tabspaces-register-buffer-kind= calls at top level (or inside a
+=:config= block on tabspaces itself), not inside a deferred block for
+the third-party package being registered.
+
 The canonical pattern shown above puts =(require 'vterm)= inside the
 restore-fn body, so the third-party package loads only when a record of
 that kind is actually being restored. For users whose package is not
@@ -439,7 +446,9 @@ pre-compiled, the first restore pays the one-time package-load cost.
             (message "tabspaces: term restore skipped (%s): %S" dir err)
             nil))))))
 
-;; ielm -- Emacs Lisp REPL.
+;; ielm -- Emacs Lisp REPL.  `ielm' did not accept a BUF-NAME argument
+;; until Emacs 29.1, so call it with no args and rename the resulting
+;; buffer when the saved name is free.
 (tabspaces-register-buffer-kind
  'ielm
  (lambda (b)
@@ -454,7 +463,13 @@ pre-compiled, the first restore pays the one-time package-load cost.
      (or (tabspaces-reuse-existing-buffer name)
          (condition-case err
              (let ((default-directory dir))
-               (ielm name))
+               (ielm)
+               (let ((buf (current-buffer)))
+                 (when (and buf
+                            (not (equal name (buffer-name buf)))
+                            (not (get-buffer name)))
+                   (with-current-buffer buf (rename-buffer name)))
+                 buf))
            (error
             (message "tabspaces: ielm restore skipped (%s): %S" dir err)
             nil))))))

--- a/tabspaces.el
+++ b/tabspaces.el
@@ -58,6 +58,11 @@
 (declare-function magit-status-setup-buffer "magit-status")
 (declare-function ibuffer-current-buffer "ibuffer" (&optional must-be-live))
 
+;; Forward declarations for buffer-kind handlers.  These special variables
+;; are defined in their respective packages, which we do not require here.
+(defvar eshell-buffer-name)
+(defvar dired-buffers)
+
 ;;;; Variables
 
 (defgroup tabspaces nil
@@ -842,14 +847,75 @@ Can be one of:
 (defvar tabspaces--session-list nil
   "Store `tabspaces' session tabs and buffers.")
 
+;;;; Buffer-kind registration
+
+(defvar tabspaces--buffer-kind-handlers nil
+  "Alist of (KIND SAVE-FN RESTORE-FN) for non-file buffer kinds.
+SAVE-FN takes a buffer and returns a plist record (with :kind) or nil.
+RESTORE-FN takes a plist record and returns the created buffer or nil.
+KIND is the symbol used as the :kind value in serialized records.
+
+The alist is walked front-to-back on save: the first SAVE-FN that
+returns non-nil for a given buffer wins.  On restore, the entry is
+looked up by KIND via `assq'.
+
+Built-in handlers for `dired', `eshell', and `shell' are registered at
+the end of this file.  User registrations issued after the package is
+loaded are prepended to this list (see
+`tabspaces-register-buffer-kind') so they take precedence on save.")
+
+(defvar tabspaces--restore-unknown-kinds nil
+  "Accumulator for unknown :kind values encountered during restore.
+Dynamically bound by `tabspaces-restore-session'; declared here so the
+helper `tabspaces--restore-buffer-record' can push to it from outside
+the let-binding scope under lexical-binding.")
+
+;;;###autoload
+(defun tabspaces-register-buffer-kind (kind save-fn restore-fn)
+  "Register handlers for non-file buffer KIND.
+SAVE-FN takes a buffer and returns a plist (with :kind KIND) or nil
+to skip the buffer.  RESTORE-FN takes such a plist and returns the
+created buffer or nil to skip the record.
+
+Re-registering KIND replaces any prior entry.  Re-registrations are
+prepended to `tabspaces--buffer-kind-handlers', so the most recently
+registered handler runs first on save.  The built-in handlers
+shipped with tabspaces are registered at the end of this file; user
+registrations issued after `(require \\='tabspaces)' therefore take
+precedence on save.
+
+Restore-fn bodies must create buffers but must NOT call
+window-configuration-changing functions like `pop-to-buffer-other-window'
+or `delete-other-windows' -- the outer restore loop wraps each
+record's handler in `save-window-excursion' and then calls
+`window-state-put' to set the final layout."
+  (setq tabspaces--buffer-kind-handlers
+        (cons (list kind save-fn restore-fn)
+              (assq-delete-all kind tabspaces--buffer-kind-handlers))))
+
 ;; Helper functions
-(defun tabspaces--buffile (b)
-  "Get filename for buffers."
-  (cl-remove-if nil (buffer-file-name b)))
+(defun tabspaces--buffer-record (b)
+  "Return a serializable session record for buffer B, or nil to skip.
+File-visiting buffers are returned as bare path strings (legacy
+format).  Other buffers are dispatched through
+`tabspaces--buffer-kind-handlers'; the first save-fn that returns
+non-nil wins."
+  (when (buffer-live-p b)
+    (with-current-buffer b
+      (cond
+       (buffer-file-name buffer-file-name)
+       (t (catch 'found
+            (dolist (entry tabspaces--buffer-kind-handlers)
+              (let ((rec (funcall (nth 1 entry) b)))
+                (when rec (throw 'found rec))))
+            nil))))))
 
 (defun tabspaces--store-buffers (bufs)
-  "Make list of filenames."
-  (flatten-tree (mapcar #'tabspaces--buffile bufs)))
+  "Return list of session records for BUFS, skipping unhandled buffers.
+Each record is either a file path string or a plist of the form
+\(:kind SYMBOL :dir DIR :name NAME ...) per
+`tabspaces--buffer-kind-handlers'."
+  (delq nil (mapcar #'tabspaces--buffer-record bufs)))
 
 ;; Save global session
 ;;;###autoload
@@ -1059,6 +1125,71 @@ Otherwise, saves everything to the global session file (traditional behavior)."
 
      (t (expand-file-name session-name project)))))
 
+(defun tabspaces--reuse-existing-buffer (name)
+  "Return the buffer named NAME iff it is already in this tab's buffer-list.
+Returns nil if no such buffer exists, or if it exists in another tab.
+Callers should fall through to create a fresh buffer when nil is returned."
+  (let ((existing (get-buffer name)))
+    (and existing
+         (memq existing (tabspaces--buffer-list))
+         existing)))
+
+(defun tabspaces--restore-buffer-record (rec)
+  "Materialize one buffer from session record REC.
+Returns the buffer created or reused, or nil if skipped.
+Pushes unknown :kind values into the dynamically-bound
+`tabspaces--restore-unknown-kinds' accumulator.  Errors signalled by a
+user-registered handler are caught and logged so one buggy handler
+does not abort the entire restore loop."
+  (cond
+   ((stringp rec) (find-file rec))
+   ((and (consp rec) (plist-get rec :kind))
+    (let* ((kind (plist-get rec :kind))
+           (entry (assq kind tabspaces--buffer-kind-handlers))
+           (restore-fn (and entry (nth 2 entry))))
+      (cond
+       (restore-fn
+        (condition-case err
+            (funcall restore-fn rec)
+          (error
+           (message "tabspaces: handler for %s signalled: %S" kind err)
+           nil)))
+       (t (push kind tabspaces--restore-unknown-kinds)
+          nil))))))
+
+(defun tabspaces--rewrite-window-state (state subst)
+  "Return STATE with buffer NAMEs substituted per alist SUBST.
+SUBST is an alist of (saved-name . actual-name) pairs.  Walks the
+three buffer-name reference shapes in window-state output: leaf
+\(buffer NAME . _) entries, (next-buffers . (NAMES)) forward history
+lists, and (prev-buffers . ((NAME M1 M2) ...)) backward history with
+marker positions.  Substituted prev-buffers entries emit (NAME 1 1)
+so `window--state-put-2' creates valid markers at position 1 -- saved
+point is lost for those slots, but navigation works without relying
+on undocumented nil-marker behaviour."
+  (cond
+   ((null subst) state)
+   ((and (consp state) (eq (car state) 'buffer) (stringp (cadr state)))
+    (let ((repl (assoc (cadr state) subst)))
+      (if repl (cons 'buffer (cons (cdr repl) (cddr state))) state)))
+   ((and (consp state) (eq (car state) 'next-buffers))
+    (cons 'next-buffers
+          (mapcar (lambda (n)
+                    (let ((r (assoc n subst))) (if r (cdr r) n)))
+                  (cdr state))))
+   ((and (consp state) (eq (car state) 'prev-buffers))
+    (cons 'prev-buffers
+          (mapcar (lambda (e)
+                    (let ((r (assoc (car e) subst)))
+                      (cond
+                       (r (list (cdr r) 1 1))
+                       (t e))))
+                  (cdr state))))
+   ((consp state)
+    (cons (tabspaces--rewrite-window-state (car state) subst)
+          (tabspaces--rewrite-window-state (cdr state) subst)))
+   (t state)))
+
 
 ;;;###autoload
 (defun tabspaces-restore-session (&optional project-or-session-file)
@@ -1094,19 +1225,50 @@ If PROJECT-OR-SESSION-FILE is:
     (if (file-exists-p session-file)
         (progn
           (load-file session-file)
-          ;; Use placeholder buffer to avoid pollution
-          (cl-loop for elm in tabspaces--session-list do
-                   (switch-to-buffer "*tabspaces--placeholder*")
-                   (tabspaces-switch-or-create-workspace (cadr elm))
-                   (mapc #'find-file (car elm))
-                   (when (caddr elm) ; If window state exists
-                     (window-state-put (caddr elm) nil 'safe)))
-          ;; Clean up placeholder buffer
-          (cl-loop for elm in tabspaces--session-list do
-                   (tabspaces-switch-or-create-workspace (cadr elm))
-                   (tabspaces-remove-selected-buffer "*tabspaces--placeholder*"))
-          (kill-buffer "*tabspaces--placeholder*")
-          (message "Restored session from %s" session-file))
+          (let ((tabspaces--restore-unknown-kinds nil)
+                (skipped-remote 0))
+            ;; Use placeholder buffer to avoid pollution
+            (cl-loop for elm in tabspaces--session-list do
+                     (switch-to-buffer "*tabspaces--placeholder*")
+                     (tabspaces-switch-or-create-workspace (cadr elm))
+                     (let ((subst nil))
+                       (save-window-excursion
+                         (dolist (rec (car elm))
+                           (let ((remote
+                                  (cond ((stringp rec) (file-remote-p rec))
+                                        ((consp rec)
+                                         (file-remote-p (plist-get rec :dir))))))
+                             (cond
+                              (remote (cl-incf skipped-remote))
+                              (t (let ((buf (tabspaces--restore-buffer-record rec))
+                                       (sname (and (consp rec)
+                                                   (plist-get rec :name))))
+                                   (when buf
+                                     (switch-to-buffer buf)
+                                     (when (and sname
+                                                (not (equal sname
+                                                            (buffer-name buf))))
+                                       (push (cons sname (buffer-name buf))
+                                             subst)))))))))
+                       (when (caddr elm) ; If window state exists
+                         (window-state-put
+                          (tabspaces--rewrite-window-state (caddr elm) subst)
+                          nil 'safe))))
+            ;; Clean up placeholder buffer
+            (cl-loop for elm in tabspaces--session-list do
+                     (tabspaces-switch-or-create-workspace (cadr elm))
+                     (tabspaces-remove-selected-buffer "*tabspaces--placeholder*"))
+            (when (get-buffer "*tabspaces--placeholder*")
+              (kill-buffer "*tabspaces--placeholder*"))
+            ;; Summary messages (informational; the final confirmation message
+            ;; below is what shows in the minibuffer)
+            (when (> skipped-remote 0)
+              (message "tabspaces: %d remote buffer(s) skipped (TRAMP)"
+                       skipped-remote))
+            (when tabspaces--restore-unknown-kinds
+              (message "tabspaces: unknown buffer kinds in session: %S"
+                       (delete-dups tabspaces--restore-unknown-kinds)))
+            (message "Restored session from %s" session-file)))
       (message "No session file found at %s" session-file))))
 
 ;; Make sure session file exists
@@ -1125,6 +1287,109 @@ unnecessary tab."
   (message "Restoring tabspaces session on startup.")
   (tabspaces--create-session-file)
   (tabspaces-restore-session))
+
+;;;; Built-in buffer-kind handlers
+
+;; These registrations must be the last top-level forms in the session section
+;; so that user registrations issued after `(require 'tabspaces)' land ahead
+;; of the built-ins in `tabspaces--buffer-kind-handlers' and take precedence
+;; on save (see `tabspaces-register-buffer-kind' docstring).
+
+;; Each handler validates `:dir' before proceeding and wraps the creation
+;; body in `condition-case' so a stale directory or transient error drops
+;; just that buffer (with a logged breadcrumb) rather than poisoning the
+;; rest of the tab's restore.
+
+(tabspaces-register-buffer-kind
+ 'dired
+ (lambda (b)
+   (with-current-buffer b
+     (when (and (derived-mode-p 'dired-mode)
+                (not (derived-mode-p 'image-dired-thumbnail-mode))
+                (not (consp dired-directory)))
+       (list :kind 'dired
+             :dir default-directory
+             :name (buffer-name)))))
+ (lambda (rec)
+   (let ((name (plist-get rec :name))
+         (dir  (plist-get rec :dir)))
+     (cond
+      ((not (and dir (stringp dir) (file-directory-p dir))) nil)
+      (t (or (tabspaces--reuse-existing-buffer name)
+             (condition-case err
+                 (let* ((default-directory dir)
+                        ;; Drop only the stale cross-tab cache entry for DIR;
+                        ;; setting `dired-buffers' to nil would orphan the new
+                        ;; advertise from the global registry.
+                        (dired-buffers
+                         (assq-delete-all (expand-file-name dir) dired-buffers))
+                        (buf (dired-noselect dir)))
+                   (when (and buf
+                              (not (equal name (buffer-name buf)))
+                              (not (get-buffer name)))
+                     (with-current-buffer buf (rename-buffer name)))
+                   buf)
+               (error
+                (message "tabspaces: dired restore skipped (%s): %S" dir err)
+                nil))))))))
+
+(tabspaces-register-buffer-kind
+ 'eshell
+ (lambda (b)
+   (with-current-buffer b
+     (when (derived-mode-p 'eshell-mode)
+       (list :kind 'eshell
+             :dir default-directory
+             :name (buffer-name)))))
+ (lambda (rec)
+   ;; Load eshell up front so `eshell-buffer-name' is declared as a
+   ;; special variable before we let-bind it.  Otherwise the let
+   ;; creates a lexical binding and eshell.el's defcustom fails on
+   ;; first load with "Defining as dynamic an already lexical var".
+   (require 'eshell)
+   (let ((name (plist-get rec :name))
+         (dir  (plist-get rec :dir)))
+     (cond
+      ((not (and dir (stringp dir) (file-directory-p dir))) nil)
+      (t (or (tabspaces--reuse-existing-buffer name)
+             (condition-case err
+                 (let* ((default-directory dir)
+                        ;; Bind the saved buffer name; (eshell t) calls
+                        ;; (generate-new-buffer eshell-buffer-name), adding a
+                        ;; `<N>' suffix on collision.  Cross-tab collisions
+                        ;; are captured by the restore loop's substitution
+                        ;; alist for window-state-put.
+                        (eshell-buffer-name name)
+                        (buf (eshell t)))
+                   buf)
+               (error
+                (message "tabspaces: eshell restore skipped (%s): %S" dir err)
+                nil))))))))
+
+(tabspaces-register-buffer-kind
+ 'shell
+ (lambda (b)
+   (with-current-buffer b
+     (when (derived-mode-p 'shell-mode)
+       (list :kind 'shell
+             :dir default-directory
+             :name (buffer-name)))))
+ (lambda (rec)
+   (let ((name (plist-get rec :name))
+         (dir  (plist-get rec :dir)))
+     (cond
+      ((not (and dir (stringp dir) (file-directory-p dir))) nil)
+      (t (or (tabspaces--reuse-existing-buffer name)
+             (condition-case err
+                 (let* ((default-directory dir)
+                        ;; `shell' reuses an existing buffer with the given
+                        ;; name (cross-tab leak risk); `generate-new-buffer-name'
+                        ;; pre-resolves to a guaranteed-unique name.
+                        (buf (shell (generate-new-buffer-name name))))
+                   buf)
+               (error
+                (message "tabspaces: shell restore skipped (%s): %S" dir err)
+                nil))))))))
 
 ;;;; Define Keymaps
 (defvar tabspaces-command-map

--- a/tabspaces.el
+++ b/tabspaces.el
@@ -2,7 +2,7 @@
 
 ;; Author: Colin McLear <mclear@fastmail.com>
 ;; Maintainer: Colin McLear
-;; Version: 1.7.1
+;; Version: 1.8.0
 ;; Package-Requires: ((emacs "27.1") (project "0.8.1"))
 ;; Keywords: convenience, frames
 ;; Homepage: https://github.com/mclear-tools/tabspaces
@@ -1388,9 +1388,12 @@ unnecessary tab."
                         ;; `<N>' suffix on collision.  Cross-tab collisions
                         ;; are captured by the restore loop's substitution
                         ;; alist for window-state-put.
-                        (eshell-buffer-name name)
-                        (buf (eshell t)))
-                   buf)
+                        (eshell-buffer-name name))
+                   (eshell t)
+                   ;; `(eshell t)' selects the new buffer, so
+                   ;; `(current-buffer)' is the reliable handle across
+                   ;; Emacs versions where the return value may differ.
+                   (current-buffer))
                (error
                 (message "tabspaces: eshell restore skipped (%s): %S" dir err)
                 nil))))))))

--- a/tabspaces.el
+++ b/tabspaces.el
@@ -866,9 +866,9 @@ loaded are prepended to this list (see
 
 (defvar tabspaces--restore-unknown-kinds nil
   "Accumulator for unknown :kind values encountered during restore.
-Dynamically bound by `tabspaces-restore-session'; declared here so the
-helper `tabspaces--restore-buffer-record' can push to it from outside
-the let-binding scope under lexical-binding.")
+Dynamically bound by `tabspaces-restore-session'.  Declared here so
+the helper `tabspaces--restore-buffer-record' can push to it from
+outside the let-binding scope under lexical-binding.")
 
 ;;;###autoload
 (defun tabspaces-register-buffer-kind (kind save-fn restore-fn)
@@ -879,8 +879,8 @@ created buffer or nil to skip the record.
 
 Re-registering KIND replaces any prior entry.  Re-registrations are
 prepended to `tabspaces--buffer-kind-handlers', so the most recently
-registered handler runs first on save.  The built-in handlers
-shipped with tabspaces are registered at the end of this file; user
+registered handler runs first on save.  The built-in handlers shipped
+with tabspaces are registered at the end of this file.  User
 registrations issued after `(require \\='tabspaces)' therefore take
 precedence on save.
 
@@ -1125,10 +1125,15 @@ Otherwise, saves everything to the global session file (traditional behavior)."
 
      (t (expand-file-name session-name project)))))
 
-(defun tabspaces--reuse-existing-buffer (name)
-  "Return the buffer named NAME iff it is already in this tab's buffer-list.
-Returns nil if no such buffer exists, or if it exists in another tab.
-Callers should fall through to create a fresh buffer when nil is returned."
+;;;###autoload
+(defun tabspaces-reuse-existing-buffer (name)
+  "Return the buffer named NAME iff it is in the current tab's buffer-list.
+Return nil if no such buffer exists, or if a buffer with NAME exists
+but in another tab.  Intended for use inside restore-fns registered
+via `tabspaces-register-buffer-kind': call this first and fall
+through to create a fresh buffer when the result is nil.  Per-tab
+dedup preserves workspace isolation when the same buffer name lives
+in multiple tabs."
   (let ((existing (get-buffer name)))
     (and existing
          (memq existing (tabspaces--buffer-list))
@@ -1138,11 +1143,17 @@ Callers should fall through to create a fresh buffer when nil is returned."
   "Materialize one buffer from session record REC.
 Returns the buffer created or reused, or nil if skipped.
 Pushes unknown :kind values into the dynamically-bound
-`tabspaces--restore-unknown-kinds' accumulator.  Errors signalled by a
-user-registered handler are caught and logged so one buggy handler
-does not abort the entire restore loop."
+`tabspaces--restore-unknown-kinds' accumulator.  Errors signalled by
+`find-file' on a legacy file record or by a user-registered handler
+are caught and logged so one bad record does not abort the entire
+restore loop."
   (cond
-   ((stringp rec) (find-file rec))
+   ((stringp rec)
+    (condition-case err
+        (find-file rec)
+      (error
+       (message "tabspaces: file restore skipped (%s): %S" rec err)
+       nil)))
    ((and (consp rec) (plist-get rec :kind))
     (let* ((kind (plist-get rec :kind))
            (entry (assq kind tabspaces--buffer-kind-handlers))
@@ -1260,8 +1271,8 @@ If PROJECT-OR-SESSION-FILE is:
                      (tabspaces-remove-selected-buffer "*tabspaces--placeholder*"))
             (when (get-buffer "*tabspaces--placeholder*")
               (kill-buffer "*tabspaces--placeholder*"))
-            ;; Summary messages (informational; the final confirmation message
-            ;; below is what shows in the minibuffer)
+            ;; Summary messages.  These are informational.  The final
+            ;; confirmation message below is what lands in the minibuffer.
             (when (> skipped-remote 0)
               (message "tabspaces: %d remote buffer(s) skipped (TRAMP)"
                        skipped-remote))
@@ -1315,20 +1326,25 @@ unnecessary tab."
          (dir  (plist-get rec :dir)))
      (cond
       ((not (and dir (stringp dir) (file-directory-p dir))) nil)
-      (t (or (tabspaces--reuse-existing-buffer name)
+      (t (or (tabspaces-reuse-existing-buffer name)
              (condition-case err
-                 (let* ((default-directory dir)
-                        ;; Drop only the stale cross-tab cache entry for DIR;
-                        ;; setting `dired-buffers' to nil would orphan the new
-                        ;; advertise from the global registry.
-                        (dired-buffers
-                         (assq-delete-all (expand-file-name dir) dired-buffers))
-                        (buf (dired-noselect dir)))
-                   (when (and buf
-                              (not (equal name (buffer-name buf)))
-                              (not (get-buffer name)))
-                     (with-current-buffer buf (rename-buffer name)))
-                   buf)
+                 (let* ((default-directory dir))
+                   ;; Drop the stale cross-tab cache entry for DIR in place.
+                   ;; A `let' rebinding would shadow the global, so the new
+                   ;; `dired-advertise' from `dired-noselect' would mutate
+                   ;; the local binding and the restored buffer would never
+                   ;; appear in the global registry.  Use `assoc-delete-all'
+                   ;; (string-key compare); `assq-delete-all' is a no-op on
+                   ;; string keys because it compares with `eq'.
+                   (setq dired-buffers
+                         (assoc-delete-all (expand-file-name dir)
+                                           dired-buffers))
+                   (let ((buf (dired-noselect dir)))
+                     (when (and buf
+                                (not (equal name (buffer-name buf)))
+                                (not (get-buffer name)))
+                       (with-current-buffer buf (rename-buffer name)))
+                     buf))
                (error
                 (message "tabspaces: dired restore skipped (%s): %S" dir err)
                 nil))))))))
@@ -1351,10 +1367,10 @@ unnecessary tab."
          (dir  (plist-get rec :dir)))
      (cond
       ((not (and dir (stringp dir) (file-directory-p dir))) nil)
-      (t (or (tabspaces--reuse-existing-buffer name)
+      (t (or (tabspaces-reuse-existing-buffer name)
              (condition-case err
                  (let* ((default-directory dir)
-                        ;; Bind the saved buffer name; (eshell t) calls
+                        ;; Bind the saved buffer name.  (eshell t) calls
                         ;; (generate-new-buffer eshell-buffer-name), adding a
                         ;; `<N>' suffix on collision.  Cross-tab collisions
                         ;; are captured by the restore loop's substitution
@@ -1379,7 +1395,7 @@ unnecessary tab."
          (dir  (plist-get rec :dir)))
      (cond
       ((not (and dir (stringp dir) (file-directory-p dir))) nil)
-      (t (or (tabspaces--reuse-existing-buffer name)
+      (t (or (tabspaces-reuse-existing-buffer name)
              (condition-case err
                  (let* ((default-directory dir)
                         ;; `shell' reuses an existing buffer with the given

--- a/tabspaces.el
+++ b/tabspaces.el
@@ -886,7 +886,7 @@ precedence on save.
 
 Restore-fn bodies must create buffers but must NOT call
 window-configuration-changing functions like `pop-to-buffer-other-window'
-or `delete-other-windows' -- the outer restore loop wraps each
+or `delete-other-windows'.  The outer restore loop wraps each
 record's handler in `save-window-excursion' and then calls
 `window-state-put' to set the final layout."
   (setq tabspaces--buffer-kind-handlers
@@ -898,7 +898,7 @@ record's handler in `save-window-excursion' and then calls
   "Return a serializable session record for buffer B, or nil to skip.
 File-visiting buffers are returned as bare path strings (legacy
 format).  Other buffers are dispatched through
-`tabspaces--buffer-kind-handlers'; the first save-fn that returns
+`tabspaces--buffer-kind-handlers'.  The first save-fn that returns
 non-nil wins."
   (when (buffer-live-p b)
     (with-current-buffer b
@@ -1142,7 +1142,8 @@ in multiple tabs."
 (defun tabspaces--restore-buffer-record (rec)
   "Materialize one buffer from session record REC.
 Returns the buffer created or reused, or nil if skipped.
-Pushes unknown :kind values into the dynamically-bound
+Pushes unknown :kind values (or the sentinel `malformed-record' for
+records that match no expected shape) into the dynamically-bound
 `tabspaces--restore-unknown-kinds' accumulator.  Errors signalled by
 `find-file' on a legacy file record or by a user-registered handler
 are caught and logged so one bad record does not abort the entire
@@ -1166,7 +1167,13 @@ restore loop."
            (message "tabspaces: handler for %s signalled: %S" kind err)
            nil)))
        (t (push kind tabspaces--restore-unknown-kinds)
-          nil))))))
+          nil))))
+   (t
+    ;; Record matched no expected shape (neither bare string nor plist
+    ;; with :kind).  Surface it via the unknown-kinds channel so the
+    ;; user gets a breadcrumb at end of restore instead of a silent drop.
+    (push 'malformed-record tabspaces--restore-unknown-kinds)
+    nil)))
 
 (defun tabspaces--rewrite-window-state (state subst)
   "Return STATE with buffer NAMEs substituted per alist SUBST.
@@ -1175,7 +1182,7 @@ three buffer-name reference shapes in window-state output: leaf
 \(buffer NAME . _) entries, (next-buffers . (NAMES)) forward history
 lists, and (prev-buffers . ((NAME M1 M2) ...)) backward history with
 marker positions.  Substituted prev-buffers entries emit (NAME 1 1)
-so `window--state-put-2' creates valid markers at position 1 -- saved
+so `window--state-put-2' creates valid markers at position 1.  Saved
 point is lost for those slots, but navigation works without relying
 on undocumented nil-marker behaviour."
   (cond
@@ -1333,9 +1340,13 @@ unnecessary tab."
                    ;; A `let' rebinding would shadow the global, so the new
                    ;; `dired-advertise' from `dired-noselect' would mutate
                    ;; the local binding and the restored buffer would never
-                   ;; appear in the global registry.  Use `assoc-delete-all'
-                   ;; (string-key compare); `assq-delete-all' is a no-op on
-                   ;; string keys because it compares with `eq'.
+                   ;; appear in the global registry.  `assoc-delete-all' is
+                   ;; the right tool here because dired keys with strings.
+                   ;; `assq-delete-all' is a no-op on string keys because it
+                   ;; compares with `eq'.  Note: in a multi-frame setup
+                   ;; this `setq' is process-global, so a session restore
+                   ;; on frame B can orphan frame A's dired buffer from
+                   ;; the registry until that buffer is reverted.
                    (setq dired-buffers
                          (assoc-delete-all (expand-file-name dir)
                                            dired-buffers))
@@ -1358,10 +1369,12 @@ unnecessary tab."
              :dir default-directory
              :name (buffer-name)))))
  (lambda (rec)
-   ;; Load eshell up front so `eshell-buffer-name' is declared as a
-   ;; special variable before we let-bind it.  Otherwise the let
-   ;; creates a lexical binding and eshell.el's defcustom fails on
-   ;; first load with "Defining as dynamic an already lexical var".
+   ;; Load eshell so `(eshell t)' below has its function definitions
+   ;; available.  The top-of-file `defvar eshell-buffer-name' already
+   ;; declares the symbol special for the byte-compiler, so this
+   ;; `require' is not for dynamic-binding semantics.  It exists to
+   ;; force eshell.el to load before a user's first restore, in case
+   ;; no earlier command has triggered the autoload.
    (require 'eshell)
    (let ((name (plist-get rec :name))
          (dir  (plist-get rec :dir)))
@@ -1399,8 +1412,9 @@ unnecessary tab."
              (condition-case err
                  (let* ((default-directory dir)
                         ;; `shell' reuses an existing buffer with the given
-                        ;; name (cross-tab leak risk); `generate-new-buffer-name'
-                        ;; pre-resolves to a guaranteed-unique name.
+                        ;; name, which would be a cross-tab leak.
+                        ;; `generate-new-buffer-name' pre-resolves to a
+                        ;; guaranteed-unique name.
                         (buf (shell (generate-new-buffer-name name))))
                    buf)
                (error


### PR DESCRIPTION
## Summary

Implements issue #30 by extending `tabspaces-save-session` /
`tabspaces-restore-session` to handle non-file buffers.

- Ships built-in handlers for `dired`, `eshell`, and `shell`. These
  are the core-Emacs buffer kinds the issue thread explicitly named.
- Exposes a public registration API,
  `tabspaces-register-buffer-kind KIND SAVE-FN RESTORE-FN`, so users
  can teach tabspaces about any other kind (vterm, eat, term, ielm,
  ...) from their config. README includes annotated vterm, term, and
  ielm examples.
- Per-tab dedup (`tabspaces-reuse-existing-buffer`) and window-state
  name substitution preserve workspace isolation across same-name
  buffer collisions.
- Restore loop wraps per-record buffer creation in
  `save-window-excursion` so handlers cannot leak window state into
  the saved layout.
- TRAMP records (both bare-string file paths and plist `:dir`
  records) are skipped at the dispatch level with a single summary
  message at end of restore.
- User-handler errors are caught and logged so one buggy handler
  cannot abort the rest of the restore loop.
- Incidentally drops the dead `(cl-remove-if nil ...)` call in the
  old `tabspaces--buffile` helper.

### Compatibility

- Old session files (strings only) load unchanged. The `stringp`
  branch of the restore dispatch handles every legacy record.
- New session files contain `(:kind ...)` plists that older versions
  cannot read. Downgrades require deleting the saved session file.
  Documented in README "Caveats" and the commit messages.
- Version bumped to `1.8.0` (new public API + on-disk format change).
- Minimum Emacs unchanged at 27.1; verified that `assoc-delete-all`,
  `save-window-excursion`, and `(eshell t)` semantics work there.
  The ielm example in the README uses the no-arg form for 27.x/28.x
  compatibility (the `BUF-NAME` argument arrived in Emacs 29.1).

## Test plan

- [x] Byte-compile clean (no new warnings; pre-existing warnings unchanged).
- [x] Manual smoke matrix, 41 checks across 12 scenarios: file
      round-trip, dired-only tab, two-tab eshell isolation, shell
      handler, legacy session compat, unknown `:kind` summary,
      window-state walker (buffer / next-buffers / prev-buffers
      slots), dired with deleted directory, TRAMP plist + bare-string
      skips, custom-handler rename via substitution, user-handler
      error containment, two-tab same-directory dired cross-tab
      isolation. All passing.
- [x] README updated with API signature, override-ordering caveats
      (including registration before `(tabspaces-mode 1)` when
      `tabspaces-session-auto-restore` is t), and three example
      handlers.
- [x] Confirmed working in an interactive Emacs against a real eshell
      workflow.

Closes #30.